### PR TITLE
Fix compile error on 32-bit targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ fn sum_of_products_pippenger<C: CurveArithmetic>(
 }
 
 #[cfg(target_pointer_width = "32")]
-fn convert_scalars<C: CurveArithmetic>(scalars: &[C::Scalar]) -> Vec<Vec<u64>> {
+fn convert_scalars<C: CurveArithmetic>(scalars: &[C::Scalar]) -> Vec<[u64; 4]> {
     scalars
         .iter()
         .map(|s| {


### PR DESCRIPTION
Mismatched return type on a variant of `fn combine_scalars` conditionally compiled on 32-bit architectures.