### PR TITLE
Make `blsful` default features optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2"
 default = ["blsful/default"]
 
 [dependencies]
-blsful = { version = "2.5", default-features = false }
+blsful = { version = "2.5.3", default-features = false }
 blake2 = "0.10"
 curve25519-dalek-ml = { version = "4.1.1", features = ["digest", "group"] }
 cait-sith = { git = "https://github.com/LIT-Protocol/cait-sith.git", features = ["k256"], optional = true }
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 sha3 = "0.10"
 thiserror = "1.0"
-vsss-rs = { version = "3.3", features = ["curve25519", "std"] }
+vsss-rs = { version = "4.0", features = ["curve25519", "std"] }
 
 [dev-dependencies]
 digest = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.2.0"
 edition = "2021"
 license = "Apache-2"
 
+[features]
+default = ["blsful/default"]
+
 [dependencies]
-blsful = "2.5"
+blsful = { version = "2.5", default-features = false }
 blake2 = "0.10"
 curve25519-dalek-ml = { version = "4.1.1", features = ["digest", "group"] }
 cait-sith = { git = "https://github.com/LIT-Protocol/cait-sith.git", features = ["k256"], optional = true }


### PR DESCRIPTION
Needed if a crate depending on this wants `blsful` to link to `bls12_381_plus` instead of `blstrs_plus`.

Merge #6 first.